### PR TITLE
Harden macOS installer flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ LITELLM_MASTER_KEY=change-me-run-openssl-rand-hex-32
 N8N_USER=admin
 # ⛔ INSECURE DEFAULT — change before first login
 N8N_PASSWORD=change-me-run-openssl-rand-hex-32
+N8N_ENCRYPTION_KEY=change-me-run-openssl-rand-hex-32
+
+# Optional n8n API key used by bootstrap workflow import.
+N8N_API_KEY=
 
 # ── SearXNG ───────────────────────────────────────────────────────────
 # Required for SearXNG to boot securely — ⛔ INSECURE DEFAULT
@@ -40,8 +44,10 @@ TZ=America/New_York
 
 # ── AI Model Selection ────────────────────────────────────────────────
 # Auto-set by install.sh based on detected RAM — override here if needed
+OLLAMA_BASE_URL=http://ollama:11434
 OPENHANDS_MODEL=ollama/qwen2.5-coder:14b
 PERPLEXICA_CHAT_MODEL=qwen2.5:32b
+QDRANT_URL=http://qdrant:6333
 
 # ── Cloud API Keys (ALL OPTIONAL) ────────────────────────────────────
 # Leave blank — stack runs 100% locally without these.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install yamllint
         run: pip install yamllint
+      - name: Install XML tools
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
       - name: Validate YAML configs
         run: |
           for f in configs/**/*.yml configs/**/*.yaml; do

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 data/
 backups/
 logs/
+certs/
 install-manifest.txt
 *.copy
 .DS_Store

--- a/configs/litellm/config.yaml
+++ b/configs/litellm/config.yaml
@@ -199,12 +199,6 @@ router_settings:
 
   # Rate limits per tier (rpm = requests per minute)
   # Prevents tiny tasks from starving heavy ones at the Ollama level.
-  model_group_alias:
-    swarm-tiny:   { tpm: 100000, rpm: 50 }
-    swarm-medium: { tpm: 50000,  rpm: 20 }
-    swarm-heavy:  { tpm: 20000,  rpm: 5  }
-    swarm-code:   { tpm: 50000,  rpm: 15 }
-
 # ── General Settings ───────────────────────────────────────────────────────────
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ volumes:
   qdrant-storage:
   n8n-data:
   perplexica-data:
-  nginx-certs:
   fail2ban-data:
 
 services:
@@ -40,18 +39,18 @@ services:
       - "443:443"
     volumes:
       - ./configs/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - nginx-certs:/etc/nginx/certs
+      - ./certs:/etc/nginx/certs:ro
     networks:
       - ai-net
     depends_on:
       open-webui:
-        condition: service_healthy
+        condition: service_started
       n8n:
-        condition: service_healthy
+        condition: service_started
       qdrant:
-        condition: service_healthy
+        condition: service_started
       litellm:
-        condition: service_healthy
+        condition: service_started
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
@@ -96,6 +95,7 @@ services:
       - WATCHTOWER_TIMEOUT=30s
       - WATCHTOWER_LOG_LEVEL=info
       - WATCHTOWER_LABEL_ENABLE=true
+      - DOCKER_API_VERSION=1.44
       - TZ=${TZ:-America/New_York}
     networks:
       - ai-net
@@ -120,12 +120,6 @@ services:
       resources:
         limits:
           memory: 20g
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 20s
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
@@ -151,13 +145,7 @@ services:
       - ai-net
     depends_on:
       ollama:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:4000/health"]
-      interval: 30s
-      timeout: 15s
-      retries: 5
-      start_period: 30s
+        condition: service_started
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
@@ -194,17 +182,11 @@ services:
       - ai-net
     depends_on:
       ollama:
-        condition: service_healthy
+        condition: service_started
       litellm:
-        condition: service_healthy
+        condition: service_started
       searxng:
         condition: service_started
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8080"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 30s
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
@@ -240,7 +222,7 @@ services:
   # Open-source Perplexity clone with citations
   # ───────────────────────────────────────────
   perplexica-backend:
-    image: itzcrazykns/perplexica-backend:main
+    image: itzcrazykns1337/perplexica-backend:main
     container_name: perplexica-backend
     restart: unless-stopped
     ports:
@@ -252,14 +234,14 @@ services:
       - ai-net
     depends_on:
       ollama:
-        condition: service_healthy
+        condition: service_started
       searxng:
         condition: service_started
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
   perplexica-frontend:
-    image: itzcrazykns/perplexica-frontend:main
+    image: itzcrazykns1337/perplexica-frontend:main
     container_name: perplexica-frontend
     restart: unless-stopped
     ports:
@@ -304,7 +286,7 @@ services:
       - ai-net
     depends_on:
       litellm:
-        condition: service_healthy
+        condition: service_started
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
@@ -324,12 +306,6 @@ services:
       - qdrant-storage:/qdrant/storage
     networks:
       - ai-net
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:6333/healthz"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 15s
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
@@ -340,7 +316,7 @@ services:
   # change to :latest (breaks silently)
   # ───────────────────────────────────────────
   n8n:
-    image: n8nio/n8n:1.87
+    image: n8nio/n8n:1.87.1
     container_name: n8n
     restart: unless-stopped
     ports:
@@ -362,11 +338,5 @@ services:
           memory: 1g
     networks:
       - ai-net
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:5678/healthz"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 30s
     labels:
       - "com.centurylinklabs.watchtower.enable=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,6 +329,7 @@ services:
       - N8N_BASIC_AUTH_USER=${N8N_USER:-admin}
       # REQUIRED: set N8N_PASSWORD in .env (install.sh auto-generates it)
       - N8N_BASIC_AUTH_PASSWORD=${N8N_PASSWORD:-REQUIRED_CHANGE_ME}
+      - N8N_ENCRYPTION_KEY=${N8N_ENCRYPTION_KEY:-REQUIRED_CHANGE_ME}
       - N8N_HOST=localhost
       - N8N_PORT=5678
       - WEBHOOK_URL=http://localhost:5678

--- a/docs/FIRMWARE_FIXES.md
+++ b/docs/FIRMWARE_FIXES.md
@@ -1,0 +1,57 @@
+# Home AI Elite Installer/Firmware Fixes
+
+Validation date: May 3, 2026
+
+This log captures the installer and stack fixes made while preparing Home AI Elite for a shareable macOS package and GitHub `main` release.
+
+## Installer fixes
+
+- Added non-interactive install support with `--non-interactive`, `--yes`, `--skip-model-pulls`, `HOME_AI_NON_INTERACTIVE`, and `HOME_AI_SKIP_MODEL_PULLS`.
+- Added Docker CLI discovery for Docker Desktop's bundled CLI at `/Applications/Docker.app/Contents/Resources/bin`.
+- Added Docker Desktop startup/wait handling on macOS when Docker is installed but not running.
+- Removed the hard dependency on Homebrew Ollama for runtime model serving; the installer now uses the Docker Ollama container.
+- Added Homebrew Ollama conflict handling so a locally running Homebrew service does not block Docker Ollama from binding `localhost:11434`.
+- Made terminal clearing safe in non-interactive runs so `clear` cannot abort the installer under `set -e`.
+- Changed health waits so timeout warnings do not abort the entire install after services are launched.
+- Generated nginx TLS certificates during install and mounted them into nginx from the repo-local `certs/` directory.
+
+## Stack fixes
+
+- Fixed the n8n image tag from `n8nio/n8n:1.87` to `n8nio/n8n:1.87.1`.
+- Fixed Perplexica image names to valid published images.
+- Replaced brittle container healthcheck dependencies with `service_started` dependencies because several upstream images do not include `curl`.
+- Updated LiteLLM readiness checks to use `http://localhost:4000`, since `/health` requires authentication on the current LiteLLM image.
+- Removed the incompatible LiteLLM `model_group_alias` block that caused startup crashes on the current LiteLLM image.
+- Set Watchtower's Docker API version explicitly to avoid restart loops against newer Docker Desktop engines.
+
+## Script fixes
+
+- Updated `scripts/bootstrap.sh` to run from the actual repository path instead of hardcoding `${HOME}/home-ai-elite`.
+- Updated bootstrap model checks and pulls to use Docker Ollama through `docker compose exec`.
+- Updated `scripts/add-model.sh` to pull and list models inside the Docker Ollama container.
+- Updated `scripts/status.sh` to check LiteLLM on the root endpoint and list Ollama models from the Docker container.
+
+## Package fixes
+
+- Updated package preinstall checks for Docker Desktop and the bundled Docker CLI.
+- Updated package postinstall to open Docker Desktop, use the bundled Docker CLI, and run `install.sh --non-interactive`.
+- Updated package documentation with the Docker Desktop requirement and corrected local service URLs.
+
+## Smoke validation
+
+The installer completed end-to-end from a clean smoke copy at `/private/tmp/home-ai-elite-smoke` using:
+
+```bash
+HOME_AI_NON_INTERACTIVE=true HOME_AI_SKIP_MODEL_PULLS=true bash install.sh --non-interactive --skip-model-pulls
+```
+
+Validated running endpoints:
+
+- Open WebUI: `http://localhost:3000`
+- Perplexica: `http://localhost:3002`
+- OpenHands: `http://localhost:3003`
+- SearXNG: `http://localhost:8080`
+- LiteLLM: `http://localhost:4000`
+- n8n: `http://localhost:5678`
+- Qdrant: `http://localhost:6333`
+- Ollama: `http://localhost:11434`

--- a/docs/INSTALLER_NOTES.md
+++ b/docs/INSTALLER_NOTES.md
@@ -1,0 +1,42 @@
+# Installer Notes
+
+These are packaging notes captured while testing from a downloaded
+`home-ai-elite-main` archive on macOS.
+
+## Observed Friction
+
+- The downloaded archive is not a Git checkout, so `git status`, branch updates,
+  and direct pushes are not available until the folder is connected to a repo.
+- Docker Desktop may install through Homebrew only with `--no-binaries` on
+  machines where `/usr/local/cli-plugins` requires sudo. In that case the Docker
+  CLI still exists at `/Applications/Docker.app/Contents/Resources/bin/docker`.
+- The installer cannot assume Docker Desktop is already running. First launch may
+  require a GUI approval/setup flow from the user.
+- Running the interactive installer from a `.pkg` postinstall script can hang on
+  hidden API-key prompts or optional setup prompts.
+- The package next-step text had stale service ports.
+
+## Changes Made
+
+- `install.sh` now supports `--non-interactive` and `--skip-model-pulls`.
+- `install.sh` and `scripts/bootstrap.sh` now discover Docker's bundled CLI when
+  shell symlinks were not created.
+- `pkg/scripts/postinstall` now runs `install.sh --non-interactive`, opens Docker
+  Desktop, and writes current service URLs to the Desktop next-steps file.
+- `pkg/scripts/preinstall` now verifies Docker's bundled CLI inside Docker.app.
+
+## GitHub Shipping Checklist
+
+- Convert the local archive into a real Git checkout or copy these changes into
+  the canonical repo.
+- Build an unsigned package locally with `bash pkg/build-pkg.sh`.
+- Test the `.pkg` on a clean macOS user account with Docker Desktop installed but
+  not yet running.
+- Decide whether public distribution should require users to install Docker
+  Desktop first, or whether the installer should download Docker Desktop during
+  setup after explicit consent.
+- For broad distribution, sign and notarize with:
+
+```bash
+bash pkg/build-pkg.sh --sign --notarize
+```

--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ wait_for_docker_engine() {
 }
 
 header() {
-  clear
+  clear 2>/dev/null || true
   echo -e "${CYAN}"
   echo '  ██╗  ██╗ ██████╗ ███╗   ███╗███████╗     █████╗ ██╗'
   echo '  ██║  ██║██╔═══██╗████╗ ████║██╔════╝    ██╔══██╗██║'
@@ -173,7 +173,7 @@ if [[ "$OS" == "Darwin" ]]; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
   log "Homebrew ready"
-  for pkg in ollama git curl jq; do
+  for pkg in git curl jq; do
     if command -v "$pkg" &>/dev/null; then
       log "$pkg already installed"
     else
@@ -189,35 +189,14 @@ else
     fi
     log "$pkg ready"
   done
-  if ! command -v ollama &>/dev/null; then
-    log "Installing Ollama..."
-    curl -fsSL https://ollama.ai/install.sh | sh
-  else
-    log "Ollama already installed"
-  fi
 fi
 
-# Start Ollama service
-if [[ "$OS" == "Darwin" ]]; then
-  if ! brew services start ollama 2>/dev/null; then
-    warn "Could not register Ollama as a background service. Starting it for this install session..."
-    nohup ollama serve >/tmp/homeai-ollama.log 2>&1 &
+if [[ "$OS" == "Darwin" ]] && command -v brew &>/dev/null; then
+  if brew services list 2>/dev/null | awk '$1 == "ollama" && $2 == "started" { found=1 } END { exit found ? 0 : 1 }'; then
+    warn "Stopping Homebrew Ollama so the Docker Ollama container can bind localhost:11434..."
+    brew services stop ollama 2>/dev/null || true
   fi
-else
-  systemctl enable ollama 2>/dev/null || true
-  systemctl start ollama 2>/dev/null || true
 fi
-
-# Wait for Ollama to be ready
-log "Waiting for Ollama to be ready..."
-OLLAMA_WAIT=0
-until curl -sf http://localhost:11434 &>/dev/null; do
-  sleep 2; OLLAMA_WAIT=$((OLLAMA_WAIT+2))
-  if (( OLLAMA_WAIT >= 60 )); then
-    err "Ollama did not start within 60s. Check: brew services list (macOS) or systemctl status ollama (Linux)"
-  fi
-done
-log "Ollama service ready"
 
 # ── STEP 3: Environment Setup & Secret Hardening ──────────────────────
 step "Environment Setup & Secret Hardening"
@@ -363,42 +342,41 @@ if [[ ! -f "configs/perplexica/config.toml" ]]; then
 fi
 log "configs/perplexica/config.toml found ✔"
 
+# 3e: Generate local TLS certificate for nginx if needed
+if [[ -f "scripts/generate-certs.sh" ]]; then
+  if [[ ! -f "certs/selfsigned.crt" || ! -f "certs/selfsigned.key" ]]; then
+    HOME_AI_STACK_DIR="${SCRIPT_DIR}" bash scripts/generate-certs.sh
+  else
+    log "Nginx TLS certificate already exists — skipping generation"
+  fi
+else
+  warn "scripts/generate-certs.sh not found — nginx HTTPS proxy may not start"
+fi
+
 # ── STEP 4: Pull Ollama Models (RAM-Aware) ────────────────────────────
 step "Pulling AI Models (Tier: ${MODEL_TIER} / ${TOTAL_RAM_GB} GB)"
 
-# ── FIX P2: Hardened model pull with registry-existence guard ─────────
-pull_model() {
-  local model=$1
-  log "Pulling ${model}..."
-  if ! ollama pull "$model"; then
-    warn "Failed to pull ${model} — skipping. Stack will continue; pull manually with: ollama pull ${model}"
-  fi
-}
+MODELS_TO_PULL=()
 
 if [[ "$SKIP_MODEL_PULLS" == true ]]; then
   warn "Skipping Ollama model pulls. Pull models later with: bash scripts/add-model.sh <model>"
 else
-  pull_model "nomic-embed-text"
+  MODELS_TO_PULL+=("nomic-embed-text")
 fi
 
 case "$MODEL_TIER" in
   low)
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "mistral:7b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:7b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || MODELS_TO_PULL+=("mistral:7b" "qwen2.5:7b")
     OPENHANDS_MODEL="ollama/qwen2.5:7b"
     PERPLEXICA_CHAT_MODEL="qwen2.5:7b"
     ;;
   base)
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:7b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5-coder:7b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "deepseek-r1:7b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || MODELS_TO_PULL+=("qwen2.5:7b" "qwen2.5-coder:7b" "deepseek-r1:7b")
     OPENHANDS_MODEL="ollama/qwen2.5-coder:7b"
     PERPLEXICA_CHAT_MODEL="qwen2.5:7b"
     ;;
   mid)
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:32b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5-coder:14b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "deepseek-r1:14b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || MODELS_TO_PULL+=("qwen2.5:32b" "qwen2.5-coder:14b" "deepseek-r1:14b")
     OPENHANDS_MODEL="ollama/qwen2.5-coder:14b"
     PERPLEXICA_CHAT_MODEL="qwen2.5:32b"
     ;;
@@ -406,10 +384,7 @@ case "$MODEL_TIER" in
     # FIX P2: Use canonical Ollama registry tag for llama3.3 70B.
     # llama3.3:70b-instruct-q4_K_M may not exist on all registry mirrors.
     # Canonical tag is llama3.3:70b (defaults to Q4_K_M quantization).
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "llama3.3:70b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:32b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5-coder:14b"
-    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "deepseek-r1:32b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || MODELS_TO_PULL+=("llama3.3:70b" "qwen2.5:32b" "qwen2.5-coder:14b" "deepseek-r1:32b")
     OPENHANDS_MODEL="ollama/qwen2.5-coder:14b"
     PERPLEXICA_CHAT_MODEL="llama3.3:70b"
     ;;
@@ -438,11 +413,8 @@ step "Pulling Docker Images & Starting All Services"
 docker compose pull --quiet
 log "Images pulled"
 
-docker compose up -d
-log "All services started"
-
-# ── STEP 6: Health Checks ─────────────────────────────────────────────
-step "Waiting for Services to be Ready"
+docker compose up -d ollama
+log "Ollama container started"
 
 wait_for_service() {
   local name=$1; local url=$2; local max_wait=${3:-90}
@@ -454,15 +426,32 @@ wait_for_service() {
     if (( elapsed >= max_wait )); then
       echo " TIMEOUT"
       warn "${name} not responding — check: docker compose logs"
-      return 1
+      return 0
     fi
   done
   echo " ✓"
   return 0
 }
 
+wait_for_service "Ollama" "http://localhost:11434" 90
+
+if (( ${#MODELS_TO_PULL[@]} > 0 )); then
+  for model in "${MODELS_TO_PULL[@]}"; do
+    log "Pulling ${model} into Docker Ollama..."
+    if ! docker compose exec -T ollama ollama pull "$model"; then
+      warn "Failed to pull ${model} — skipping. Stack will continue; pull manually with: bash scripts/add-model.sh ${model}"
+    fi
+  done
+fi
+
+docker compose up -d
+log "All services started"
+
+# ── STEP 6: Health Checks ─────────────────────────────────────────────
+step "Waiting for Services to be Ready"
+
 wait_for_service "Ollama"        "http://localhost:11434"        60
-wait_for_service "LiteLLM"       "http://localhost:4000/health"  120
+wait_for_service "LiteLLM"       "http://localhost:4000"         120
 wait_for_service "Open WebUI"    "http://localhost:3000"         90
 wait_for_service "SearXNG"       "http://localhost:8080"         60
 wait_for_service "Qdrant"        "http://localhost:6333/healthz" 60
@@ -475,8 +464,12 @@ FIRST_BOOT_FLAG="${SCRIPT_DIR}/.wizard-bootstrapped"
 if [[ ! -f "$FIRST_BOOT_FLAG" ]]; then
   if [[ -f "scripts/bootstrap.sh" ]]; then
     log "Running first-boot bootstrap (Qdrant collections + n8n workflows)..."
-    bash "${SCRIPT_DIR}/scripts/bootstrap.sh" && touch "$FIRST_BOOT_FLAG"
-    log "Bootstrap complete"
+    if HOME_AI_STACK_DIR="${SCRIPT_DIR}" bash "${SCRIPT_DIR}/scripts/bootstrap.sh"; then
+      touch "$FIRST_BOOT_FLAG"
+      log "Bootstrap complete"
+    else
+      warn "Bootstrap reported issues — run manually after install: bash scripts/bootstrap.sh"
+    fi
   else
     warn "scripts/bootstrap.sh not found — run manually after install"
   fi

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,35 @@
 # ╚══════════════════════════════════════════════════════════════╝
 set -euo pipefail
 
+NON_INTERACTIVE="${HOME_AI_NON_INTERACTIVE:-false}"
+SKIP_MODEL_PULLS="${HOME_AI_SKIP_MODEL_PULLS:-false}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --non-interactive|--yes)
+      NON_INTERACTIVE=true
+      ;;
+    --skip-model-pulls)
+      SKIP_MODEL_PULLS=true
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: bash install.sh [options]
+
+Options:
+  --non-interactive   Do not prompt for optional API keys or setup choices.
+  --skip-model-pulls  Start services without pulling Ollama models.
+  -h, --help          Show this help.
+
+Environment:
+  HOME_AI_NON_INTERACTIVE=true
+  HOME_AI_SKIP_MODEL_PULLS=true
+EOF
+      exit 0
+      ;;
+  esac
+done
+
 # ── Colors ────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
 BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
@@ -15,6 +44,44 @@ warn()   { echo -e "${YELLOW}[!]${NC} $1"; }
 err()    { echo -e "${RED}[✗]${NC} $1"; exit 1; }
 step()   { echo -e "\n${BLUE}${BOLD}━━━ $1 ━━━${NC}"; }
 info()   { echo -e "${CYAN}[i]${NC} $1"; }
+
+ensure_docker_cli() {
+  if command -v docker &>/dev/null; then
+    return 0
+  fi
+
+  local docker_app_cli="/Applications/Docker.app/Contents/Resources/bin"
+  if [[ -x "${docker_app_cli}/docker" ]]; then
+    export PATH="${docker_app_cli}:$PATH"
+    return 0
+  fi
+
+  return 1
+}
+
+wait_for_docker_engine() {
+  if docker info &>/dev/null; then
+    return 0
+  fi
+
+  if [[ "$(uname -s)" == "Darwin" ]] && [[ -d "/Applications/Docker.app" ]]; then
+    warn "Docker Desktop is installed but not running. Opening Docker Desktop..."
+    open -a Docker >/dev/null 2>&1 || true
+
+    local elapsed=0
+    until docker info &>/dev/null; do
+      sleep 5
+      elapsed=$((elapsed + 5))
+      if (( elapsed >= 300 )); then
+        return 1
+      fi
+      (( elapsed % 30 == 0 )) && info "Still waiting for Docker Desktop (${elapsed}s)..."
+    done
+    return 0
+  fi
+
+  return 1
+}
 
 header() {
   clear
@@ -88,10 +155,10 @@ else
 fi
 
 # Docker check
-if ! command -v docker &>/dev/null; then
+if ! ensure_docker_cli; then
   err "Docker not found. Install Docker Desktop: https://docker.com/products/docker-desktop then re-run."
 fi
-if ! docker info &>/dev/null; then
+if ! wait_for_docker_engine; then
   err "Docker is not running. Start Docker Desktop and re-run."
 fi
 DOCKER_COMPOSE_VERSION=$(docker compose version --short 2>/dev/null || echo "0")
@@ -132,7 +199,10 @@ fi
 
 # Start Ollama service
 if [[ "$OS" == "Darwin" ]]; then
-  brew services start ollama 2>/dev/null || true
+  if ! brew services start ollama 2>/dev/null; then
+    warn "Could not register Ollama as a background service. Starting it for this install session..."
+    nohup ollama serve >/tmp/homeai-ollama.log 2>&1 &
+  fi
 else
   systemctl enable ollama 2>/dev/null || true
   systemctl start ollama 2>/dev/null || true
@@ -223,6 +293,11 @@ prompt_api_key() {
     return
   fi
 
+  if [[ "$NON_INTERACTIVE" == true ]]; then
+    info "${key} skipped — non-interactive install"
+    return
+  fi
+
   echo ""
   echo -e "  ${YELLOW}${BOLD}${label}${NC}"
   echo -e "  ${CYAN}Get it at: ${url}${NC}"
@@ -254,11 +329,15 @@ prompt_api_key() {
   done
 }
 
-echo ""
-echo -e "  ${CYAN}${BOLD}━━━ Optional: Cloud API Keys ━━━${NC}"
-echo -e "  The stack runs ${BOLD}100% locally${NC} without any of these."
-echo -e "  Add keys only if you want cloud model fallback for complex tasks."
-echo -e "  ${YELLOW}Keys are entered in hidden mode — they will NOT be echoed to screen.${NC}\n"
+if [[ "$NON_INTERACTIVE" == true ]]; then
+  info "Non-interactive mode enabled — optional cloud API key prompts will be skipped."
+else
+  echo ""
+  echo -e "  ${CYAN}${BOLD}━━━ Optional: Cloud API Keys ━━━${NC}"
+  echo -e "  The stack runs ${BOLD}100% locally${NC} without any of these."
+  echo -e "  Add keys only if you want cloud model fallback for complex tasks."
+  echo -e "  ${YELLOW}Keys are entered in hidden mode — they will NOT be echoed to screen.${NC}\n"
+fi
 
 prompt_api_key "OPENAI_API_KEY" \
   "OpenAI API Key  (GPT-4o fallback)" \
@@ -296,26 +375,30 @@ pull_model() {
   fi
 }
 
-pull_model "nomic-embed-text"
+if [[ "$SKIP_MODEL_PULLS" == true ]]; then
+  warn "Skipping Ollama model pulls. Pull models later with: bash scripts/add-model.sh <model>"
+else
+  pull_model "nomic-embed-text"
+fi
 
 case "$MODEL_TIER" in
   low)
-    pull_model "mistral:7b"
-    pull_model "qwen2.5:7b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "mistral:7b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:7b"
     OPENHANDS_MODEL="ollama/qwen2.5:7b"
     PERPLEXICA_CHAT_MODEL="qwen2.5:7b"
     ;;
   base)
-    pull_model "qwen2.5:7b"
-    pull_model "qwen2.5-coder:7b"
-    pull_model "deepseek-r1:7b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:7b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5-coder:7b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "deepseek-r1:7b"
     OPENHANDS_MODEL="ollama/qwen2.5-coder:7b"
     PERPLEXICA_CHAT_MODEL="qwen2.5:7b"
     ;;
   mid)
-    pull_model "qwen2.5:32b"
-    pull_model "qwen2.5-coder:14b"
-    pull_model "deepseek-r1:14b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:32b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5-coder:14b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "deepseek-r1:14b"
     OPENHANDS_MODEL="ollama/qwen2.5-coder:14b"
     PERPLEXICA_CHAT_MODEL="qwen2.5:32b"
     ;;
@@ -323,10 +406,10 @@ case "$MODEL_TIER" in
     # FIX P2: Use canonical Ollama registry tag for llama3.3 70B.
     # llama3.3:70b-instruct-q4_K_M may not exist on all registry mirrors.
     # Canonical tag is llama3.3:70b (defaults to Q4_K_M quantization).
-    pull_model "llama3.3:70b"
-    pull_model "qwen2.5:32b"
-    pull_model "qwen2.5-coder:14b"
-    pull_model "deepseek-r1:32b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "llama3.3:70b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5:32b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "qwen2.5-coder:14b"
+    [[ "$SKIP_MODEL_PULLS" == true ]] || pull_model "deepseek-r1:32b"
     OPENHANDS_MODEL="ollama/qwen2.5-coder:14b"
     PERPLEXICA_CHAT_MODEL="llama3.3:70b"
     ;;
@@ -425,25 +508,33 @@ fi
 # ── STEP 9: Optional MCP Servers ──────────────────────────────────────
 step "MCP Server Setup (Optional)"
 if [[ -f "mcp/install-mcp-servers.sh" ]]; then
-  echo -e "  ${YELLOW}Install MCP servers? (GitHub + filesystem + Qdrant MCP) [y/N]${NC}"
-  read -r INSTALL_MCP
-  if [[ "$INSTALL_MCP" =~ ^[Yy]$ ]]; then
-    bash mcp/install-mcp-servers.sh
+  if [[ "$NON_INTERACTIVE" == true ]]; then
+    warn "Skipped MCP server install in non-interactive mode — run manually: bash mcp/install-mcp-servers.sh"
   else
-    warn "Skipped — run manually: bash mcp/install-mcp-servers.sh"
+    echo -e "  ${YELLOW}Install MCP servers? (GitHub + filesystem + Qdrant MCP) [y/N]${NC}"
+    read -r INSTALL_MCP
+    if [[ "$INSTALL_MCP" =~ ^[Yy]$ ]]; then
+      bash mcp/install-mcp-servers.sh
+    else
+      warn "Skipped — run manually: bash mcp/install-mcp-servers.sh"
+    fi
   fi
 fi
 
 # ── STEP 10: LaunchD Auto-Start (macOS only) ───────────────────────────
 if [[ "$OS" == "Darwin" ]] && [[ -f "launchd/install-launchd.sh" ]]; then
   step "macOS Auto-Start (LaunchD)"
-  echo -e "  ${YELLOW}Install launchd agents for auto-start on login? [y/N]${NC}"
-  read -r INSTALL_LAUNCHD
-  if [[ "$INSTALL_LAUNCHD" =~ ^[Yy]$ ]]; then
-    bash launchd/install-launchd.sh
-    log "LaunchD agents installed — Wizard will auto-start on login"
+  if [[ "$NON_INTERACTIVE" == true ]]; then
+    warn "Skipped launchd setup in non-interactive mode — run manually: bash launchd/install-launchd.sh"
   else
-    warn "Skipped — run manually: bash launchd/install-launchd.sh"
+    echo -e "  ${YELLOW}Install launchd agents for auto-start on login? [y/N]${NC}"
+    read -r INSTALL_LAUNCHD
+    if [[ "$INSTALL_LAUNCHD" =~ ^[Yy]$ ]]; then
+      bash launchd/install-launchd.sh
+      log "LaunchD agents installed — Wizard will auto-start on login"
+    else
+      warn "Skipped — run manually: bash launchd/install-launchd.sh"
+    fi
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -257,6 +257,7 @@ rotate_secret() {
 rotate_secret "WEBUI_SECRET_KEY"
 rotate_secret "LITELLM_MASTER_KEY"
 rotate_secret "N8N_PASSWORD"
+rotate_secret "N8N_ENCRYPTION_KEY"
 rotate_secret "SEARXNG_SECRET_KEY"
 
 # ── 3c: Secure interactive prompt for cloud API keys ──────────────────

--- a/launchd/com.homeai.backup.plist
+++ b/launchd/com.homeai.backup.plist
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key>

--- a/launchd/com.homeai.backup.plist
+++ b/launchd/com.homeai.backup.plist
@@ -12,7 +12,6 @@
     <string>/Users/Shared/home-ai-elite/scripts/backup.sh</string>
   </array>
 
-  <!-- Run daily at 2:00 AM -->
   <key>StartCalendarInterval</key>
   <dict>
     <key>Hour</key>

--- a/launchd/com.homeai.docker.plist
+++ b/launchd/com.homeai.docker.plist
@@ -42,7 +42,7 @@
   <key>StandardErrorPath</key>
   <string>/tmp/homeai-docker.log</string>
 
-  <!-- Do NOT restart continuously -- Docker manages itself once open -->
+  <!-- Docker manages itself once open -->
   <key>KeepAlive</key>
   <false/>
 </dict>

--- a/launchd/com.homeai.docker.plist
+++ b/launchd/com.homeai.docker.plist
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
   com.homeai.docker.plist
   Starts Docker Desktop on macOS login.

--- a/launchd/com.homeai.stack.plist
+++ b/launchd/com.homeai.stack.plist
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
   com.homeai.stack.plist
   Starts all AI services (docker compose up) 30 seconds after login.

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -35,15 +35,26 @@ Output: `home-ai-elite-<version>.pkg` in the repo root.
 ## Install Flow (what happens when user double-clicks)
 
 1. macOS Installer.app shows Welcome + Readme screens
-2. `preinstall` runs: checks macOS ≥13, RAM ≥8GB, disk ≥20GB, Docker installed, git installed
+2. `preinstall` runs: checks macOS ≥13, RAM ≥8GB, disk ≥20GB, Docker Desktop installed, git installed
 3. If all checks pass: files copied to `/usr/local/home-ai-elite`
 4. `postinstall` runs:
    - Copies stack to `~/home-ai-elite`
    - Creates `.env` from `.env.example`
-   - Launches `install.sh` in background (pulls Docker images, starts services)
+   - Opens Docker Desktop so the user can finish first-run setup
+   - Launches `install.sh --non-interactive` in background (pulls Docker images, starts services)
    - Installs launchd auto-start agents
    - Drops a **Next Steps** file on the Desktop
-5. Done — services start automatically, user opens `http://localhost:3001`
+5. Done — services start automatically after Docker Desktop is running, user opens `http://localhost:3000`
+
+## Docker Desktop Caveat
+
+The package does not bundle Docker Desktop. Users should install and open Docker
+Desktop before running Home AI Elite. If Docker Desktop is installed without
+shell symlinks, the installer uses Docker's bundled CLI at:
+
+```bash
+/Applications/Docker.app/Contents/Resources/bin/docker
+```
 
 ## Signing & Notarization
 

--- a/pkg/scripts/postinstall
+++ b/pkg/scripts/postinstall
@@ -54,21 +54,39 @@ if [[ ! -f "${USER_INSTALL_DIR}/.env" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 4. Run install.sh as the user (background, logged)
+# 4. Make Docker Desktop CLI available even when cask binary linking was skipped
 # ---------------------------------------------------------------------------
-log "  Launching install.sh as $INSTALLING_USER (background)..."
-su - "$INSTALLING_USER" -c \
-  "cd '${USER_INSTALL_DIR}' && bash install.sh >> '${LOG_FILE}' 2>&1" &
+DOCKER_APP_CLI="/Applications/Docker.app/Contents/Resources/bin"
+if [[ -x "${DOCKER_APP_CLI}/docker" ]]; then
+  log "  ✅ Docker CLI available at ${DOCKER_APP_CLI}/docker"
+else
+  log "  ⚠ Docker CLI missing. Install Docker Desktop, then run: cd ~/home-ai-elite && bash install.sh"
+fi
 
 # ---------------------------------------------------------------------------
-# 5. Install launchd agents for auto-start
+# 5. Launch Docker Desktop for first-run setup
+# ---------------------------------------------------------------------------
+if [[ -d "/Applications/Docker.app" ]]; then
+  log "  Opening Docker Desktop for first-run setup..."
+  su - "$INSTALLING_USER" -c "open -a Docker" >> "$LOG_FILE" 2>&1 || true
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Run install.sh as the user (background, logged)
+# ---------------------------------------------------------------------------
+log "  Launching non-interactive install.sh as $INSTALLING_USER (background)..."
+su - "$INSTALLING_USER" -c \
+  "cd '${USER_INSTALL_DIR}' && PATH='${DOCKER_APP_CLI}':\$PATH HOME_AI_NON_INTERACTIVE=true bash install.sh --non-interactive >> '${LOG_FILE}' 2>&1" &
+
+# ---------------------------------------------------------------------------
+# 7. Install launchd agents for auto-start
 # ---------------------------------------------------------------------------
 log "  Installing launchd auto-start agents..."
 su - "$INSTALLING_USER" -c \
   "bash '${USER_INSTALL_DIR}/launchd/install-launchd.sh' >> '${LOG_FILE}' 2>&1" || true
 
 # ---------------------------------------------------------------------------
-# 6. Write post-install instructions
+# 8. Write post-install instructions
 # ---------------------------------------------------------------------------
 cat > "${INSTALLING_HOME}/Desktop/home-ai-elite-next-steps.txt" << 'INSTRUCTIONS'
 ┌────────────────────────────────────────────────┐
@@ -76,17 +94,21 @@ cat > "${INSTALLING_HOME}/Desktop/home-ai-elite-next-steps.txt" << 'INSTRUCTIONS
 │                                            │
 │  NEXT STEPS:                               │
 │                                            │
-│  1. Open Terminal                          │
-│  2. cd ~/home-ai-elite                     │
-│  3. nano .env   (add your API keys)        │
-│  4. bash scripts/bootstrap.sh             │
+│  1. Open Docker Desktop and finish setup   │
+│  2. Open Terminal                          │
+│  3. cd ~/home-ai-elite                     │
+│  4. bash scripts/status.sh                 │
+│  5. Optional: nano .env                    │
+│  6. Optional: bash scripts/bootstrap.sh    │
 │                                            │
-│  YOUR SERVICES (after bootstrap):          │
-│   Open WebUI  → http://localhost:3001      │
+│  YOUR SERVICES:                            │
+│   Open WebUI  → http://localhost:3000      │
+│   Perplexica  → http://localhost:3002      │
+│   OpenHands   → http://localhost:3003      │
 │   n8n         → http://localhost:5678      │
-│   Perplexica  → http://localhost:3000      │
 │   Qdrant      → http://localhost:6333      │
 │   SearXNG     → http://localhost:8080      │
+│   LiteLLM     → http://localhost:4000      │
 │                                            │
 │  Install log: /tmp/homeai-install.log      │
 │  Uninstall:   bash ~/home-ai-elite/        │

--- a/pkg/scripts/preinstall
+++ b/pkg/scripts/preinstall
@@ -7,7 +7,7 @@
 #   1. macOS version >= 13 (Ventura)
 #   2. Available RAM >= 8GB
 #   3. Available disk space >= 20GB
-#   4. Docker Desktop installed
+#   4. Docker Desktop installed and launchable
 #   5. Git installed
 # =============================================================================
 #!/usr/bin/env bash
@@ -55,6 +55,11 @@ if [[ ! -d "/Applications/Docker.app" ]]; then
   fail "Docker Desktop is required but not installed.\n  Download: https://www.docker.com/products/docker-desktop/"
 fi
 log "  ✅ Docker Desktop found"
+
+if [[ ! -x "/Applications/Docker.app/Contents/Resources/bin/docker" ]]; then
+  fail "Docker Desktop is installed, but the Docker CLI was not found inside Docker.app."
+fi
+log "  ✅ Docker CLI found inside Docker.app"
 
 # ---------------------------------------------------------------------------
 # 5. Git check

--- a/scripts/add-model.sh
+++ b/scripts/add-model.sh
@@ -3,6 +3,16 @@
 # Usage: bash scripts/add-model.sh <model-name>
 # Browse: https://ollama.com/library
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACK_DIR="${HOME_AI_STACK_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  DOCKER_APP_CLI="/Applications/Docker.app/Contents/Resources/bin"
+  if [[ -x "${DOCKER_APP_CLI}/docker" ]]; then
+    export PATH="${DOCKER_APP_CLI}:$PATH"
+  fi
+fi
+
 if [[ -z "${1:-}" ]]; then
   echo "Usage: bash scripts/add-model.sh <model-name>"
   echo ""
@@ -17,10 +27,11 @@ if [[ -z "${1:-}" ]]; then
   exit 1
 fi
 
+cd "$STACK_DIR"
 MODEL="$1"
 echo "Pulling: $MODEL"
-ollama pull "$MODEL"
+docker compose exec -T ollama ollama pull "$MODEL"
 echo ""
 echo "Done. Model available at http://localhost:11434"
 echo ""
-ollama list
+docker compose exec -T ollama ollama list

--- a/scripts/add-model.sh
+++ b/scripts/add-model.sh
@@ -27,7 +27,7 @@ if [[ -z "${1:-}" ]]; then
   exit 1
 fi
 
-cd "$STACK_DIR"
+cd "$STACK_DIR" || exit 1
 MODEL="$1"
 echo "Pulling: $MODEL"
 docker compose exec -T ollama ollama pull "$MODEL"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -16,7 +16,8 @@
 # =============================================================================
 set -euo pipefail
 
-STACK_DIR="${HOME}/home-ai-elite"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACK_DIR="${HOME_AI_STACK_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 COMPOSE_FILE="${STACK_DIR}/docker-compose.yml"
 ENV_FILE="${STACK_DIR}/.env"
 WORKFLOW_DIR="${STACK_DIR}/n8n-workflows"
@@ -192,16 +193,16 @@ fi
 # Step 6: Ollama model check
 # ---------------------------------------------------------------------------
 banner "Step 6/7: Ollama Models"
-if command -v ollama >/dev/null 2>&1; then
-  MODEL_COUNT=$(ollama list 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
+if docker compose ps ollama >/dev/null 2>&1; then
+  MODEL_COUNT=$(docker compose exec -T ollama ollama list 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')
   if [[ "$MODEL_COUNT" -eq 0 ]]; then
     log "Pulling default model: $OLLAMA_DEFAULT_MODEL"
-    ollama pull "$OLLAMA_DEFAULT_MODEL" || warn "Model pull failed — retry with: ollama pull $OLLAMA_DEFAULT_MODEL"
+    docker compose exec -T ollama ollama pull "$OLLAMA_DEFAULT_MODEL" || warn "Model pull failed — retry with: bash scripts/add-model.sh $OLLAMA_DEFAULT_MODEL"
   else
     log "  ✅ $MODEL_COUNT Ollama model(s) already present — skipping pull"
   fi
 else
-  warn "Ollama CLI not found in PATH — open http://localhost:11434 to verify Ollama is running in Docker"
+  warn "Ollama container not running — open http://localhost:11434 after the stack starts"
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -111,8 +111,10 @@ if [[ ! -f "$ENV_FILE" ]]; then
 fi
 
 # Source .env so N8N_API_KEY and QDRANT_* overrides are picked up
-# shellcheck source=/dev/null
-set -a; source "$ENV_FILE" 2>/dev/null || true; set +a
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE" 2>/dev/null || true
+set +a
 
 # ---------------------------------------------------------------------------
 # Step 2: Start stack

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,6 +38,20 @@ fail()   { echo "[bootstrap] ERROR: $*" >&2; exit 1; }
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+ensure_docker_cli() {
+  if command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local docker_app_cli="/Applications/Docker.app/Contents/Resources/bin"
+  if [[ -x "${docker_app_cli}/docker" ]]; then
+    export PATH="${docker_app_cli}:$PATH"
+    return 0
+  fi
+
+  return 1
+}
+
 wait_for_http() {
   local url="$1"
   local label="$2"
@@ -84,6 +98,7 @@ echo -e "${RESET}"
 banner "Step 1/7: Preflight"
 [[ -d "$STACK_DIR" ]] || fail "Missing $STACK_DIR — re-run the installer"
 [[ -f "$COMPOSE_FILE" ]] || fail "Missing docker-compose.yml"
+ensure_docker_cli || fail "Docker CLI not found — install Docker Desktop first"
 docker info >/dev/null 2>&1 || fail "Docker engine not running — open Docker Desktop first"
 log "  ✅ Preflight passed"
 
@@ -197,11 +212,13 @@ echo -e "${GREEN}${BOLD}"
 echo "  ╔══════════════════════════════════════════╗"
 echo "  ║  SERVICE               URL                 ║"
 echo "  ╠══════════════════════════════════════════╣"
-echo "  ║  Open WebUI            http://localhost:3001 ║"
+echo "  ║  Open WebUI            http://localhost:3000 ║"
+echo "  ║  Perplexica Search     http://localhost:3002 ║"
+echo "  ║  OpenHands Agent       http://localhost:3003 ║"
 echo "  ║  n8n Automation        http://localhost:5678 ║"
-echo "  ║  Perplexica Search     http://localhost:3000 ║"
 echo "  ║  Qdrant Dashboard      http://localhost:6333 ║"
 echo "  ║  SearXNG               http://localhost:8080 ║"
+echo "  ║  LiteLLM Router        http://localhost:4000 ║"
 echo "  ║  Ollama API            http://localhost:11434 ║"
 echo "  ╚══════════════════════════════════════════╝"
 echo -e "${RESET}"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -111,13 +111,14 @@ if [[ ! -f "$ENV_FILE" ]]; then
 fi
 
 # Source .env so N8N_API_KEY and QDRANT_* overrides are picked up
+# shellcheck source=/dev/null
 set -a; source "$ENV_FILE" 2>/dev/null || true; set +a
 
 # ---------------------------------------------------------------------------
 # Step 2: Start stack
 # ---------------------------------------------------------------------------
 banner "Step 2/7: Starting Services"
-cd "$STACK_DIR"
+cd "$STACK_DIR" || exit 1
 docker compose up -d
 log "  ✅ docker compose up -d complete"
 

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # home-ai-elite — Generate self-signed TLS certificate for Nginx (v0.7)
 # Run once on first boot. Re-run to regenerate.
-# Output: ~/home-ai-elite/certs/selfsigned.crt + selfsigned.key
+# Output: <repo>/certs/selfsigned.crt + selfsigned.key
 
 set -euo pipefail
 
-CERTS_DIR="${HOME}/home-ai-elite/certs"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+STACK_DIR="${HOME_AI_STACK_DIR:-$( cd "${SCRIPT_DIR}/.." && pwd )}"
+CERTS_DIR="${HOME_AI_CERTS_DIR:-${STACK_DIR}/certs}"
 DAYS=3650  # 10-year self-signed cert
 
 mkdir -p "${CERTS_DIR}"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -2,6 +2,16 @@
 # Home AI Elite — Service Health Dashboard
 # Usage: bash scripts/status.sh
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STACK_DIR="${HOME_AI_STACK_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  DOCKER_APP_CLI="/Applications/Docker.app/Contents/Resources/bin"
+  if [[ -x "${DOCKER_APP_CLI}/docker" ]]; then
+    export PATH="${DOCKER_APP_CLI}:$PATH"
+  fi
+fi
+
 GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'
 CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
 
@@ -21,15 +31,16 @@ check "Open WebUI  (Chat UI)       " "http://localhost:3000"           3000
 check "Perplexica  (Search AI)     " "http://localhost:3002"           3002
 check "OpenHands   (Codex Agent)   " "http://localhost:3003"           3003
 check "SearXNG     (Web Search)    " "http://localhost:8080"           8080
-check "LiteLLM     (Model Router)  " "http://localhost:4000/health"    4000
+check "LiteLLM     (Model Router)  " "http://localhost:4000"           4000
 check "n8n         (Automation)    " "http://localhost:5678"           5678
 check "Qdrant      (Vector Memory) " "http://localhost:6333/healthz"   6333
 check "Ollama      (AI Brain)      " "http://localhost:11434"          11434
 
 echo ""
 echo -e "${BOLD}Docker Containers:${NC}"
+cd "$STACK_DIR"
 docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || docker ps
 echo ""
 echo -e "${BOLD}Ollama Models Loaded:${NC}"
-ollama list 2>/dev/null || echo "  Ollama not running locally"
+docker compose exec -T ollama ollama list 2>/dev/null || echo "  Ollama container not running"
 echo ""

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -38,7 +38,7 @@ check "Ollama      (AI Brain)      " "http://localhost:11434"          11434
 
 echo ""
 echo -e "${BOLD}Docker Containers:${NC}"
-cd "$STACK_DIR"
+cd "$STACK_DIR" || exit 1
 docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || docker ps
 echo ""
 echo -e "${BOLD}Ollama Models Loaded:${NC}"


### PR DESCRIPTION
## Summary
- add non-interactive install mode and optional model-pull skipping for package installs
- discover Docker Desktop's bundled CLI when shell symlinks are unavailable
- update package pre/postinstall flow, current service URLs, and installer notes

## Validation
- bash -n install.sh
- bash -n scripts/bootstrap.sh
- bash -n pkg/scripts/preinstall
- bash -n pkg/scripts/postinstall
- bash install.sh --help
- git diff --check