### PR TITLE
feat: hardware-aware model guidance — hardware_probe module + /status/hardware endpoint

### DIFF
--- a/merlin/hardware_probe.py
+++ b/merlin/hardware_probe.py
@@ -1,0 +1,249 @@
+"""Hardware detection for Merlin AI.
+
+Pure read-only probe. No side effects. No external dependencies beyond stdlib.
+This is a Python port of the ram_gb() and hardware_tier() logic in scripts/doctor.sh
+so that the FastAPI status layer can expose hardware context without shelling out.
+
+Tier thresholds must stay in sync with:
+  - configs/merlin/hardware-tiers.yaml
+  - configs/merlin/model-tiers.env
+  - scripts/doctor.sh::hardware_tier()
+
+Tracked issue: #118 (model library / hardware-aware model guidance)
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Tier thresholds — mirror hardware-tiers.yaml exactly
+# ---------------------------------------------------------------------------
+
+_TIERS: list[dict[str, Any]] = [
+    {
+        "tier": "high",
+        "ram_gb_min": 48,
+        "ram_gb_max": None,
+        "max_model_class": "70b",
+        "quantization": "q4/q5 or better",
+        "default_profile": "core",
+        "suggested_profiles": ["search", "automation", "coding", "ops"],
+        "disabled_profiles": [],
+        "recommended_models": ["llama3.3:70b", "qwen2.5:32b", "deepseek-r1:32b", "nomic-embed-text"],
+        "warning": "High-memory tier: full stack available, but risky actions still require approval.",
+    },
+    {
+        "tier": "mid",
+        "ram_gb_min": 24,
+        "ram_gb_max": 47,
+        "max_model_class": "32b",
+        "quantization": "q4/q5/q6",
+        "default_profile": "core",
+        "suggested_profiles": ["search", "automation"],
+        "disabled_profiles": [],
+        "recommended_models": ["qwen2.5:32b", "qwen2.5-coder:14b", "deepseek-r1:14b", "nomic-embed-text"],
+        "warning": "Workstation tier: Magic Mode can run with approval gates.",
+    },
+    {
+        "tier": "base",
+        "ram_gb_min": 16,
+        "ram_gb_max": 23,
+        "max_model_class": "14b",
+        "quantization": "q4/q5",
+        "default_profile": "core",
+        "suggested_profiles": ["search"],
+        "disabled_profiles": [],
+        "recommended_models": ["qwen2.5:7b", "qwen2.5-coder:7b", "deepseek-r1:7b", "nomic-embed-text"],
+        "warning": "Developer laptop tier: run one heavy model or agent task at a time.",
+    },
+    {
+        "tier": "low",
+        "ram_gb_min": 8,
+        "ram_gb_max": 15,
+        "max_model_class": "7b",
+        "quantization": "q4",
+        "default_profile": "core",
+        "suggested_profiles": [],
+        "disabled_profiles": ["search", "automation", "coding", "security", "ops"],
+        "recommended_models": ["qwen2.5:7b", "nomic-embed-text"],
+        "warning": "Low-memory mode: avoid OpenHands, full search stack, and models above 7B.",
+    },
+    {
+        "tier": "unsupported",
+        "ram_gb_min": 0,
+        "ram_gb_max": 7,
+        "max_model_class": "none",
+        "quantization": "none",
+        "default_profile": "none",
+        "suggested_profiles": [],
+        "disabled_profiles": ["search", "automation", "coding", "security", "ops", "core"],
+        "recommended_models": [],
+        "warning": "RAM is below minimum supported tier (8 GB). Consider a hardware refresh.",
+    },
+]
+
+_UNKNOWN_TIER: dict[str, Any] = {
+    "tier": "unknown",
+    "ram_gb_min": None,
+    "ram_gb_max": None,
+    "max_model_class": "7b",
+    "quantization": "q4",
+    "default_profile": "core",
+    "suggested_profiles": [],
+    "disabled_profiles": [],
+    "recommended_models": ["qwen2.5:7b", "nomic-embed-text"],
+    "warning": "RAM could not be detected. Defaulting to conservative 7B Q4 guidance.",
+}
+
+
+# ---------------------------------------------------------------------------
+# RAM detection — stdlib only, mirrors doctor.sh logic
+# ---------------------------------------------------------------------------
+
+def _ram_bytes_macos() -> int | None:
+    """Read hw.memsize via sysctl on macOS."""
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if result.returncode == 0:
+            return int(result.stdout.strip())
+    except Exception:
+        pass
+    return None
+
+
+def _ram_bytes_linux() -> int | None:
+    """Read MemTotal from /proc/meminfo on Linux."""
+    try:
+        text = Path("/proc/meminfo").read_text(encoding="utf-8")
+        match = re.search(r"^MemTotal:\s+(\d+)\s+kB", text, re.MULTILINE)
+        if match:
+            return int(match.group(1)) * 1024
+    except Exception:
+        pass
+    return None
+
+
+def ram_gb() -> int:
+    """Return total physical RAM in whole GB. Returns 0 if detection fails."""
+    system = platform.system()
+    raw: int | None = None
+    if system == "Darwin":
+        raw = _ram_bytes_macos()
+    elif system == "Linux":
+        raw = _ram_bytes_linux()
+    if raw and raw > 0:
+        return raw // (1024 ** 3)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Tier resolution
+# ---------------------------------------------------------------------------
+
+def hardware_tier(ram: int) -> dict[str, Any]:
+    """Return the tier definition dict for a given RAM value (GB).
+
+    Returns the _UNKNOWN_TIER sentinel when ram == 0 (detection failure).
+    """
+    if ram <= 0:
+        return _UNKNOWN_TIER
+    for tier in _TIERS:
+        min_gb = tier["ram_gb_min"]
+        max_gb = tier["ram_gb_max"]
+        if ram >= min_gb and (max_gb is None or ram <= max_gb):
+            return tier
+    return _UNKNOWN_TIER
+
+
+# ---------------------------------------------------------------------------
+# CPU / platform supplemental info (best-effort, no error on failure)
+# ---------------------------------------------------------------------------
+
+def _cpu_info() -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "physical_cores": None,
+        "logical_cores": None,
+        "architecture": platform.machine(),
+        "avx512_support": None,
+    }
+    try:
+        import os as _os
+        info["logical_cores"] = _os.cpu_count()
+    except Exception:
+        pass
+
+    system = platform.system()
+    if system == "Linux":
+        try:
+            cpuinfo = Path("/proc/cpuinfo").read_text(encoding="utf-8")
+            # physical cores via unique core id × physical id combos
+            cores = set()
+            phys_id = core_id = ""
+            for line in cpuinfo.splitlines():
+                if line.startswith("physical id"):
+                    phys_id = line.split(":", 1)[1].strip()
+                elif line.startswith("core id"):
+                    core_id = line.split(":", 1)[1].strip()
+                    cores.add((phys_id, core_id))
+            if cores:
+                info["physical_cores"] = len(cores)
+            info["avx512_support"] = "avx512f" in cpuinfo.lower()
+        except Exception:
+            pass
+    elif system == "Darwin":
+        try:
+            import subprocess
+            r = subprocess.run(
+                ["sysctl", "-n", "hw.physicalcpu"],
+                capture_output=True, text=True, timeout=3,
+            )
+            if r.returncode == 0:
+                info["physical_cores"] = int(r.stdout.strip())
+        except Exception:
+            pass
+
+    return info
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def hardware_profile() -> dict[str, Any]:
+    """Return a complete, read-only hardware profile dict.
+
+    This is the single source of truth for the /status/hardware endpoint.
+    Zero side effects. Safe to call on every request.
+    """
+    detected_ram = ram_gb()
+    tier_def = hardware_tier(detected_ram)
+
+    return {
+        "ram_gb": detected_ram,
+        "tier": tier_def["tier"],
+        "max_model_class": tier_def["max_model_class"],
+        "quantization": tier_def["quantization"],
+        "default_profile": tier_def["default_profile"],
+        "suggested_profiles": tier_def["suggested_profiles"],
+        "disabled_profiles": tier_def["disabled_profiles"],
+        "recommended_models": tier_def["recommended_models"],
+        "warning": tier_def["warning"],
+        "cpu": _cpu_info(),
+        "os": platform.system(),
+        "detection_source": (
+            "hw.memsize (sysctl)" if platform.system() == "Darwin"
+            else "/proc/meminfo" if platform.system() == "Linux"
+            else "unsupported_platform"
+        ),
+        "tier_config_source": "configs/merlin/hardware-tiers.yaml",
+        "mode": "read_only_hardware_probe",
+    }

--- a/merlin/status_extension.py
+++ b/merlin/status_extension.py
@@ -14,6 +14,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from merlin.config_loader import load_all_configs
+from merlin.hardware_probe import hardware_profile
 from merlin.memory_manager import MemoryManager
 from merlin.provider_connector_store import (
     ProviderConnectorRecord,
@@ -228,6 +229,35 @@ def _write_provider_connector_audit(action: str, record: ProviderConnectorRecord
         return None
 
 
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/hardware")
+def status_hardware() -> dict[str, Any]:
+    """Return a read-only hardware profile for this machine.
+
+    Detects RAM, maps to a hardware tier, and returns the tier's model and
+    profile guidance. Zero side effects. Safe to call on every dashboard load.
+
+    Response fields:
+      ram_gb            – detected total physical RAM in whole GB (0 = unknown)
+      tier              – one of: high / mid / base / low / unsupported / unknown
+      max_model_class   – largest model class safe for this tier (e.g. "7b", "32b")
+      quantization      – recommended quant level(s) for this tier
+      default_profile   – Merlin profile recommended at startup
+      suggested_profiles– profiles safe to enable with approval
+      disabled_profiles – profiles that should NOT run on this tier by default
+      recommended_models– Ollama model names appropriate for this tier
+      warning           – human-readable guidance string for this tier
+      cpu               – best-effort CPU info (physical_cores, avx512_support, ...)
+      os                – platform.system() value
+      detection_source  – how RAM was read (sysctl / /proc/meminfo)
+      tier_config_source– canonical config file these thresholds come from
+    """
+    return hardware_profile()
+
+
 @router.get("/routes")
 def status_routes() -> dict[str, Any]:
     config = _load_config_quietly()
@@ -345,6 +375,12 @@ def status_models() -> dict[str, Any]:
     default_chat_alias = config.models.defaults.default_chat_model
     default_embedding_alias = config.models.defaults.default_embedding_model
 
+    # Pull hardware tier so model guidance is hardware-aware
+    hw = hardware_profile()
+    hw_tier = hw["tier"]
+    hw_max_class = hw["max_model_class"]
+    hw_recommended = hw["recommended_models"]
+
     try:
         installed_models = _ollama_tags()
         degraded = False
@@ -370,6 +406,7 @@ def status_models() -> dict[str, Any]:
             "install_command": f"bash scripts/add-model.sh {model.model}",
             "download_policy": "manual_only",
             "confirmation_required": True,
+            "hardware_recommended": model.model in hw_recommended,
         }
         local_models.append(record)
         if model.model_class == "embedding":
@@ -416,6 +453,9 @@ def status_models() -> dict[str, Any]:
         "downloads": "manual_only",
         "manual_confirmation_required": True,
         "low_memory_warning": LOW_MEMORY_MODEL_WARNING,
+        "hardware_tier": hw_tier,
+        "hardware_max_model_class": hw_max_class,
+        "hardware_recommended_models": hw_recommended,
     }
 
 


### PR DESCRIPTION
## What this does

Adds **hardware-aware model guidance** to Merlin's status API. Every time the dashboard loads, it now knows what hardware tier the machine is running on and surfaces that context directly — no shell scripts, no manual lookup.

---

## Changes

### `merlin/hardware_probe.py` (new)
- Pure Python port of `doctor.sh` `ram_gb()` / `hardware_tier()` logic
- stdlib only — no new dependencies
- Detects RAM via `hw.memsize` (macOS sysctl) or `/proc/meminfo` (Linux)
- Maps RAM → tier using the same thresholds as `configs/merlin/hardware-tiers.yaml`
- Returns CPU supplemental info: physical cores, logical cores, architecture, AVX-512 support flag
- Zero side effects — safe to call on every request
- Tier thresholds stay in sync with `hardware-tiers.yaml` and `model-tiers.env`

### `merlin/status_extension.py` (updated)
- Imports `hardware_profile` from `merlin.hardware_probe`
- Adds `GET /status/hardware` — new read-only endpoint, full hardware profile response
- Enriches `GET /status/models` with three new fields:
  - `hardware_tier` — tier name for this machine
  - `hardware_max_model_class` — largest model class safe for this tier
  - `hardware_recommended_models` — Ollama model names appropriate for this tier
  - `hardware_recommended` flag per model record

---

## `/status/hardware` response shape

```json
{
  "ram_gb": 16,
  "tier": "base",
  "max_model_class": "14b",
  "quantization": "q4/q5",
  "default_profile": "core",
  "suggested_profiles": ["search"],
  "disabled_profiles": [],
  "recommended_models": ["qwen2.5:7b", "qwen2.5-coder:7b", "deepseek-r1:7b", "nomic-embed-text"],
  "warning": "Developer laptop tier: run one heavy model or agent task at a time.",
  "cpu": {
    "physical_cores": 8,
    "logical_cores": 16,
    "architecture": "x86_64",
    "avx512_support": true
  },
  "os": "Linux",
  "detection_source": "/proc/meminfo",
  "tier_config_source": "configs/merlin/hardware-tiers.yaml"
}
```

---

## Roadmap fit

This is the Phase 1 trigger for hardware-aware model routing described in the AI coding assistant roadmap. The `/status/hardware` endpoint becomes the single source of truth for:
- Dashboard model guidance UI (#118)
- Automated model tier selection at Merlin startup
- Future: `config_loader` integration so profile defaults are hardware-aware at boot

---

## Testing

```bash
# Start the API
bash scripts/start-services.sh

# Verify the new endpoint
curl -s http://localhost:8000/status/hardware | python3 -m json.tool

# Verify models endpoint now includes hardware fields
curl -s http://localhost:8000/status/models | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['hardware_tier'], d['hardware_max_model_class'])"
```

---

## Notes
- `hardware_probe.py` is stdlib-only — no pip additions required
- Tier thresholds are defined once in `_TIERS` inside `hardware_probe.py`; any future threshold change must also update `hardware-tiers.yaml` and `doctor.sh` (noted in module docstring)
- Windows is not supported by the RAM probe; `ram_gb()` returns `0` and the endpoint returns `tier: unknown` with conservative 7B Q4 fallback guidance

Closes #118 (partial — model library guidance layer, hardware detection side)